### PR TITLE
Prevent encoding special chars on requests.

### DIFF
--- a/lib/Trello/HttpClient/HttpClient.php
+++ b/lib/Trello/HttpClient/HttpClient.php
@@ -389,7 +389,7 @@ class HttpClient implements HttpClientInterface
 
         if ($httpMethod === 'GET' && $body) {
             $path .= (false === strpos($path, '?') ? '?' : '&');
-            $path .= utf8_encode(http_build_query($body, '', '&'));
+            $path .= urldecode(utf8_encode(http_build_query($body, '', '&')));
         }
 
         return new Request(


### PR DESCRIPTION
When I do a GET request to trello adding GET parameters with commas in their value, the request returns an incorrect result.

Example:

```php
      $project_id = 123;
      $params = [
        'fields' => 'id,fullName,username,avatarUrl',
      ];
      $members = $this->client->api('boards')->members()->all($project_id, $params);
```

Here I should receive:
```
[
  [
    'id' => 1,
    'fullName' => 'John Doeh',
    'avatarUrl' => 'https://trello-avatar-url',
    'username' => 'johndoe23',
  ]
...
]
```

But I receive:
```
[
  [
    'id' => 1,
  ]
...
]
```

That is happening because the parameters are being encoded when creating the request. This PR solves it.

Could you check this and if it's okay for you merge? Thank you!!!