### PR TITLE
Make http client work with HTTP 2/0, the current protocol of Trello.

### DIFF
--- a/lib/Trello/Client.php
+++ b/lib/Trello/Client.php
@@ -67,6 +67,7 @@ class Client implements ClientInterface
         'api_limit'   => 5000,
         'api_version' => 1,
         'cache_dir'   => null,
+        'curl'        => [CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_2_0],
     );
 
     /**


### PR DESCRIPTION
Now trello uses http 2.0 as protocol. Because of that, we were receiving a 426 http error doing the calls to the trello api using the library.

The problem is produced by one  curl options that guzzle adds to the request: CURL_HEADERFUNCTION, in this line of code: https://github.com/guzzle/guzzle/blob/master/src/Handler/CurlFactory.php#L66

This problem is solved specifying the protocol is HTTP 2.0, what is done in this pull request.

Please review, thanks!
